### PR TITLE
Add statistics

### DIFF
--- a/parquet/Cargo.toml
+++ b/parquet/Cargo.toml
@@ -59,7 +59,7 @@ tempfile = "3.0"
 brotli = "3.3"
 flate2 = "1.0"
 lz4 = "1.23"
-zstd = "0.11"
+zstd = "0.10"
 serde_json = { version = "1.0", features = ["preserve_order"] }
 arrow = { path = "../arrow", version = "16.0.0", default-features = false, features = ["ipc", "test_utils", "prettyprint"] }
 

--- a/parquet/src/arrow/arrow_reader.rs
+++ b/parquet/src/arrow/arrow_reader.rs
@@ -982,7 +982,7 @@ mod tests {
             row_group_writer.close()?;
         }
 
-        writer.close()
+        writer.close().map(|(metadata,_)| metadata)
     }
 
     fn get_test_reader(file_name: &str) -> Arc<SerializedFileReader<File>> {

--- a/parquet/src/arrow/arrow_writer.rs
+++ b/parquet/src/arrow/arrow_writer.rs
@@ -38,6 +38,7 @@ use crate::column::writer::ColumnWriter;
 use crate::errors::{ParquetError, Result};
 use crate::file::metadata::RowGroupMetaDataPtr;
 use crate::file::properties::WriterProperties;
+use crate::file::statistics::Statistics;
 use crate::file::writer::{SerializedColumnWriter, SerializedRowGroupWriter};
 use crate::{data_type::*, file::writer::SerializedFileWriter};
 
@@ -203,7 +204,7 @@ impl<W: Write> ArrowWriter<W> {
     }
 
     /// Close and finalize the underlying Parquet writer
-    pub fn close(mut self) -> Result<parquet_format::FileMetaData> {
+    pub fn close(mut self) -> Result<(parquet_format::FileMetaData, Vec<Option<Statistics>>)> {
         self.flush()?;
         self.writer.close()
     }


### PR DESCRIPTION
When writing a Parquet file, you get a Statistics object per column. It gives
you the min and max value as well as the number of nulls.

