### PR TITLE
feat: annotate parquet schema with field-ids

### DIFF
--- a/arrow-schema/src/datatype.rs
+++ b/arrow-schema/src/datatype.rs
@@ -363,10 +363,11 @@ impl DataType {
                             && a.data_type().equals_datatype(b.data_type())
                     })
             }
-            (
-                DataType::Map(a_field, a_is_sorted),
-                DataType::Map(b_field, b_is_sorted),
-            ) => a_field == b_field && a_is_sorted == b_is_sorted,
+            (DataType::Map(a, a_is_sorted), DataType::Map(b, b_is_sorted)) => {
+                a.is_nullable() == b.is_nullable()
+                    && a.data_type().equals_datatype(b.data_type())
+                    && a_is_sorted == b_is_sorted
+            }
             _ => self == other,
         }
     }

--- a/parquet/src/arrow/schema.rs
+++ b/parquet/src/arrow/schema.rs
@@ -516,7 +516,8 @@ fn arrow_to_parquet_type(field: &Field) -> Result<Type> {
         DataType::Union(_, _, _) => unimplemented!("See ARROW-8817."),
         DataType::Dictionary(_, ref value) => {
             // Dictionary encoding not handled at the schema level
-            let dict_field = Field::new(name, *value.clone(), field.is_nullable());
+            let dict_field = Field::new(name, *value.clone(), field.is_nullable())
+                .with_metadata(field.metadata().cloned());
             arrow_to_parquet_type(&dict_field)
         }
     }

--- a/parquet/src/schema/types.rs
+++ b/parquet/src/schema/types.rs
@@ -267,6 +267,12 @@ impl<'a> PrimitiveTypeBuilder<'a> {
         self
     }
 
+    /// Sets optional field id and returns itself.
+    pub fn with_option_id(mut self, id: Option<i32>) -> Self {
+        self.id = id;
+        self
+    }
+
     /// Creates a new `PrimitiveType` instance from the collected attributes.
     /// Returns `Err` in case of any building conditions are not met.
     pub fn build(self) -> Result<Type> {
@@ -580,6 +586,12 @@ impl<'a> GroupTypeBuilder<'a> {
     /// Sets optional field id and returns itself.
     pub fn with_id(mut self, id: i32) -> Self {
         self.id = Some(id);
+        self
+    }
+
+    /// Sets optional field id and returns itself.
+    pub fn with_option_id(mut self, id: Option<i32>) -> Self {
+        self.id = id;
         self
     }
 


### PR DESCRIPTION
If the arrow schema's fields have a field-id in their metadata, then parse that as an i32 and use as the parquet field-id.